### PR TITLE
Skills, Augs, and Auras name filters

### DIFF
--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -17,7 +17,7 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th><input v-model="filterQuery"/></th>
+              <th><input v-model="filterQuery" placeholder="Filter"/></th>
               <th>
                 <input
                   type="range"

--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -48,6 +48,7 @@
 
 <script>
 import Augmentation from "./Augmentation.vue";
+import { filterText } from "../helpers";
 
 export default {
   name: "Augmentations",
@@ -67,7 +68,7 @@ export default {
       return this.$store.getters.augmentationErrors;
     },
     augmentations() {
-      let all = [
+      let collection = [
         "archmages_endurance",
         "asherons_benediction",
         "asherons_lesser_benediction",
@@ -114,13 +115,7 @@ export default {
         "yoshis_essence"
       ]
 
-      return all.filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        }
-      );
+      return filterText(this.filterQuery, collection);
     },
     filterPresent() {
       return this.filterQuery !== "";

--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -17,7 +17,10 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th><input v-model="filterQuery" placeholder="Filter"/></th>
+              <th>
+                <input v-model="filterQuery" class="w60" placeholder="Filter"/>
+                <button v-if="filterPresent" @click="clearFilter">x</button>
+              </th>
               <th>
                 <input
                   type="range"
@@ -119,6 +122,9 @@ export default {
         }
       );
     },
+    filterPresent() {
+      return this.filterQuery !== "";
+    },
   },
   methods: {
     changeInvested(e) {
@@ -127,6 +133,9 @@ export default {
     toggle() {
       this.$store.commit("toggleAugmentationsPane");
     },
+    clearFilter() {
+      this.filterQuery = "";
+    }
   },
 };
 </script>

--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -10,6 +10,7 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
+        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -31,50 +32,11 @@
             </tr>
           </thead>
           <tbody>
-            <Augmentation name="archmages_endurance" />
-            <Augmentation name="asherons_benediction" />
-            <Augmentation name="asherons_lesser_benediction" />
-            <Augmentation name="blackmoors_favor" />
-            <Augmentation name="bleearghs_fortitude" />
-            <Augmentation name="caustic_enhancement" />
-            <Augmentation name="celdiseths_essence" />
-            <Augmentation name="charmed_smith" />
-            <Augmentation name="ciandras_essence" />
-            <Augmentation name="ciandras_fortune" />
-            <Augmentation name="clutch_of_the_miser" />
-            <Augmentation name="critical_protection" />
-            <Augmentation name="enduring_calm" />
-            <Augmentation name="enduring_enchantment" />
-            <Augmentation name="enhancement_of_the_arrow_turner" />
-            <Augmentation name="enhancement_of_the_blade_turner" />
-            <Augmentation name="enhancement_of_the_mace_turner" />
-            <Augmentation name="eye_of_the_remorseless" />
-            <Augmentation name="fiery_enhancement" />
-            <Augmentation name="frenzy_of_the_slayer" />
-            <Augmentation name="hand_of_the_remorseless" />
-            <Augmentation name="icy_enhancement" />
-            <Augmentation name="infused_creature_magic" />
-            <Augmentation name="infused_item_magic" />
-            <Augmentation name="infused_life_magic" />
-            <Augmentation name="infused_void_magic" />
-            <Augmentation name="infused_war_magic" />
-            <Augmentation name="innate_renewal" />
-            <Augmentation name="iron_skin_of_the_invincible" />
-            <Augmentation name="jack_of_all_trades" />
-            <Augmentation name="jibrils_essence" />
-            <Augmentation name="kogas_essence" />
-            <Augmentation name="master_of_the_five_fold_path" />
-            <Augmentation name="master_of_the_focused_eye" />
-            <Augmentation name="master_of_the_steel_circle" />
-            <Augmentation name="might_of_the_seventh_mule" />
-            <Augmentation name="oswalds_enhancement" />
-            <Augmentation name="quick_learner" />
-            <Augmentation name="reinforcement_of_the_lugians" />
-            <Augmentation name="shadow_of_the_seventh_mule" />
-            <Augmentation name="siraluuns_blessing" />
-            <Augmentation name="steadfast_will" />
-            <Augmentation name="storms_enhancement" />
-            <Augmentation name="yoshis_essence" />
+            <Augmentation
+              v-for="(augmentation) in augmentations"
+              :key="augmentation"
+              :name="augmentation"
+            />
           </tbody>
         </table>
       </div>
@@ -90,12 +52,73 @@ export default {
   components: {
     Augmentation,
   },
+  data() {
+    return {
+      filterQuery: "",
+    }
+  },
   computed: {
     collapsed() {
       return this.$store.getters.augmentationsPaneVisible;
     },
     errors() {
       return this.$store.getters.augmentationErrors;
+    },
+    augmentations() {
+      let all = [
+        "archmages_endurance",
+        "asherons_benediction",
+        "asherons_lesser_benediction",
+        "blackmoors_favor",
+        "bleearghs_fortitude",
+        "caustic_enhancement",
+        "celdiseths_essence",
+        "charmed_smith",
+        "ciandras_essence",
+        "ciandras_fortune",
+        "clutch_of_the_miser",
+        "critical_protection",
+        "enduring_calm",
+        "enduring_enchantment",
+        "enhancement_of_the_arrow_turner",
+        "enhancement_of_the_blade_turner",
+        "enhancement_of_the_mace_turner",
+        "eye_of_the_remorseless",
+        "fiery_enhancement",
+        "frenzy_of_the_slayer",
+        "hand_of_the_remorseless",
+        "icy_enhancement",
+        "infused_creature_magic",
+        "infused_item_magic",
+        "infused_life_magic",
+        "infused_void_magic",
+        "infused_war_magic",
+        "innate_renewal",
+        "iron_skin_of_the_invincible",
+        "jack_of_all_trades",
+        "jibrils_essence",
+        "kogas_essence",
+        "master_of_the_five_fold_path",
+        "master_of_the_focused_eye",
+        "master_of_the_steel_circle",
+        "might_of_the_seventh_mule",
+        "oswalds_enhancement",
+        "quick_learner",
+        "reinforcement_of_the_lugians",
+        "shadow_of_the_seventh_mule",
+        "siraluuns_blessing",
+        "steadfast_will",
+        "storms_enhancement",
+        "yoshis_essence"
+      ]
+
+      return all.filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        }
+      );
     },
   },
   methods: {

--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -10,7 +10,6 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
-        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -18,7 +17,7 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th>&nbsp;</th>
+              <th><input v-model="filterQuery"/></th>
               <th>
                 <input
                   type="range"

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -17,7 +17,7 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th><input v-model="filterQuery"/></th>
+              <th><input v-model="filterQuery" placeholder="Filter"/></th>
               <th>
                 <input
                   type="range"

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -48,6 +48,7 @@
 
 <script>
 import LuminanceAura from "./LuminanceAura.vue";
+import { filterText } from "../helpers";
 
 export default {
   name: "LuminanceAuras",
@@ -67,7 +68,7 @@ export default {
       return this.$store.getters.auraErrors;
     },
     auras() {
-      let all = [
+      let collection = [
         "aetheric_vision",
         "craftsman",
         "destruction",
@@ -86,13 +87,7 @@ export default {
         "world"
       ];
 
-      return all.filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        }
-      );
+      return filterText(this.filterQuery, collection);
     },
     filterPresent() {
       return this.filterQuery !== "";

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -17,7 +17,10 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th><input v-model="filterQuery" placeholder="Filter"/></th>
+              <th>
+                <input v-model="filterQuery" class="w60" placeholder="Filter"/>
+                <button v-if="filterPresent" @click="clearFilter">x</button>
+              </th>
               <th>
                 <input
                   type="range"
@@ -91,6 +94,9 @@ export default {
         }
       );
     },
+    filterPresent() {
+      return this.filterQuery !== "";
+    },
   },
   methods: {
     changeInvested(e) {
@@ -98,6 +104,9 @@ export default {
     },
     toggle() {
       this.$store.commit("toggleAurasPane");
+    },
+    clearFilter() {
+      this.filterQuery = "";
     },
   },
 };

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -10,7 +10,6 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
-        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -18,7 +17,7 @@
               <th colspan="2">Invested</th>
             </tr>
             <tr class="controls">
-              <th>&nbsp;</th>
+              <th><input v-model="filterQuery"/></th>
               <th>
                 <input
                   type="range"

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -10,6 +10,7 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
+        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -31,22 +32,11 @@
             </tr>
           </thead>
           <tbody>
-            <LuminanceAura name="aetheric_vision" />
-            <LuminanceAura name="craftsman" />
-            <LuminanceAura name="destruction" />
-            <LuminanceAura name="glory" />
-            <LuminanceAura name="hardening" />
-            <LuminanceAura name="invulnerability" />
-            <LuminanceAura name="mana_flow" />
-            <LuminanceAura name="mana_infusion" />
-            <LuminanceAura name="protection" />
-            <LuminanceAura name="purity" />
-            <LuminanceAura name="retribution" />
-            <LuminanceAura name="skill" />
-            <LuminanceAura name="specialization" />
-            <LuminanceAura name="temperance" />
-            <LuminanceAura name="valor" />
-            <LuminanceAura name="world" />
+            <LuminanceAura
+              v-for="(aura) in auras"
+              :key="aura"
+              :name="aura"
+            />
           </tbody>
         </table>
       </div>
@@ -62,12 +52,45 @@ export default {
   components: {
     LuminanceAura,
   },
+  data() {
+    return {
+      filterQuery: "",
+    }
+  },
   computed: {
     collapsed() {
       return this.$store.getters.aurasPaneVisible;
     },
     errors() {
       return this.$store.getters.auraErrors;
+    },
+    auras() {
+      let all = [
+        "aetheric_vision",
+        "craftsman",
+        "destruction",
+        "glory",
+        "hardening",
+        "invulnerability",
+        "mana_flow",
+        "mana_infusion",
+        "protection",
+        "purity",
+        "retribution",
+        "skill",
+        "specialization",
+        "temperance",
+        "valor",
+        "world"
+      ];
+
+      return all.filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        }
+      );
     },
   },
   methods: {

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -40,7 +40,7 @@
               <th>Cantrip</th>
             </tr>
             <tr class="controls">
-              <th colspan="4"><input v-model="filterQuery"/></th>
+              <th colspan="4"><input v-model="filterQuery" placeholder="Filter"/></th>
               <th>&nbsp;</th>
               <th>&nbsp;</th>
               <th colspan="2">

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -20,6 +20,7 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
+        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -154,6 +155,11 @@ import { MAX_SPECIALIZED_SKILL_CREDITS_SPENT } from "../constants";
 export default {
   name: "Skills",
   components: { Skill },
+  data() {
+    return {
+      filterQuery: "",
+    }
+  },
   computed: {
     collapsed() {
       return this.$store.getters.skillsPaneVisible;
@@ -199,32 +205,52 @@ export default {
       }
     },
     specializedSkills() {
-      return Object.keys(this.$store.state.build.character.skills).filter(
-        (key) =>
+      return Object.keys(this.$store.state.build.character.skills)
+        .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.SPECIALIZED
-      );
+          Training.SPECIALIZED)
+        .filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        });
     },
     trainedSkills() {
-      return Object.keys(this.$store.state.build.character.skills).filter(
-        (key) =>
-          this.$store.state.build.character.skills[key].training ===
-          Training.TRAINED
-      );
+      return Object.keys(this.$store.state.build.character.skills)
+        .filter((key) =>
+          this.$store.state.build.character.skills[key].training === 
+          Training.TRAINED)
+        .filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        });
     },
     untrainedSkills() {
-      return Object.keys(this.$store.state.build.character.skills).filter(
-        (key) =>
+      return Object.keys(this.$store.state.build.character.skills)
+        .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.UNTRAINED
-      );
+          Training.UNTRAINED)
+        .filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        });
     },
     unusableSkills() {
-      return Object.keys(this.$store.state.build.character.skills).filter(
-        (key) =>
+      return Object.keys(this.$store.state.build.character.skills)
+        .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.UNUSABLE
-      );
+          Training.UNUSABLE)
+        .filter(key => {
+          return this.filterQuery
+            .toLowerCase()
+            .split(" ")
+            .every(v => key.toLowerCase().includes(v));
+        });
     },
     noSpecializedSkills() {
       return this.$store.getters.specializedSkills.length == 0;

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -153,6 +153,7 @@
 import Skill from "./Skill.vue";
 import { Training } from "../types";
 import { MAX_SPECIALIZED_SKILL_CREDITS_SPENT } from "../constants";
+import { filterText } from "../helpers";
 
 export default {
   name: "Skills",
@@ -207,52 +208,37 @@ export default {
       }
     },
     specializedSkills() {
-      return Object.keys(this.$store.state.build.character.skills)
+      let collection = Object.keys(this.$store.state.build.character.skills)
         .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.SPECIALIZED)
-        .filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        });
+          Training.SPECIALIZED
+        );
+      return filterText(this.filterQuery, collection);
+    
     },
     trainedSkills() {
-      return Object.keys(this.$store.state.build.character.skills)
+      let collection = Object.keys(this.$store.state.build.character.skills)
         .filter((key) =>
           this.$store.state.build.character.skills[key].training === 
-          Training.TRAINED)
-        .filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        });
+          Training.TRAINED
+        );
+      return filterText(this.filterQuery, collection);
     },
     untrainedSkills() {
-      return Object.keys(this.$store.state.build.character.skills)
+      let collection = Object.keys(this.$store.state.build.character.skills)
         .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.UNTRAINED)
-        .filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        });
+          Training.UNTRAINED
+        );    
+      return filterText(this.filterQuery, collection);
     },
     unusableSkills() {
-      return Object.keys(this.$store.state.build.character.skills)
+      let collection = Object.keys(this.$store.state.build.character.skills)
         .filter((key) =>
           this.$store.state.build.character.skills[key].training ===
-          Training.UNUSABLE)
-        .filter(key => {
-          return this.filterQuery
-            .toLowerCase()
-            .split(" ")
-            .every(v => key.toLowerCase().includes(v));
-        });
+          Training.UNUSABLE
+      );
+      return filterText(this.filterQuery, collection);
     },
     noSpecializedSkills() {
       return this.$store.getters.specializedSkills.length == 0;

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -20,7 +20,6 @@
         </div>
       </div>
       <div v-if="collapsed" class="table-wrapper">
-        <input v-model="filterQuery"/>
         <table>
           <thead>
             <tr class="table-header">
@@ -41,7 +40,7 @@
               <th>Cantrip</th>
             </tr>
             <tr class="controls">
-              <th colspan="4">&nbsp;</th>
+              <th colspan="4"><input v-model="filterQuery"/></th>
               <th>&nbsp;</th>
               <th>&nbsp;</th>
               <th colspan="2">

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -40,7 +40,10 @@
               <th>Cantrip</th>
             </tr>
             <tr class="controls">
-              <th colspan="4"><input v-model="filterQuery" placeholder="Filter"/></th>
+              <th colspan="4">
+                <input v-model="filterQuery" class="w60" placeholder="Filter"/>
+                <button v-if="filterPresent" @click="clearFilter">x</button>
+              </th>
               <th>&nbsp;</th>
               <th>&nbsp;</th>
               <th colspan="2">
@@ -257,6 +260,9 @@ export default {
     noTrainedSkills() {
       return this.$store.getters.trainedSkills.length == 0;
     },
+    filterPresent() {
+      return this.filterQuery !== "";
+    },
   },
   methods: {
     toggle() {
@@ -270,6 +276,9 @@ export default {
     },
     changeCantrips(e) {
       this.$store.commit("changeAllSkillCantrips", e.target.value);
+    },
+    clearFilter() {
+      this.filterQuery = "";
     },
   },
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -158,3 +158,12 @@ export const clamp = function (value: number, clamp: number): number {
 
   return value;
 };
+
+export const filterText = function (text: string, collection: string[]): string[] {
+  return collection.filter(key => 
+    text
+      .toLowerCase()
+      .split(" ")
+      .every(v => key.toLowerCase().includes(v))
+  );
+};


### PR DESCRIPTION
See Issue: https://github.com/amoeba/accharplanner/issues/391

- Filter text field in the "controls" section to make use of the blank space under name. I could see how the "Invested", "Buff", and "Cantrip" controls (that affects all) could get misunderstood, but maybe not
- The clear "x" button when filter text is present

Feel free to take this and run with it or guide me and I'm happy to do it. 👍 
Disclaimer: Still learning Vue. I appreciate any tips on improving this.

Empty Filter:
<img width="545" alt="empty_filter" src="https://user-images.githubusercontent.com/1517368/187212903-86bdb52d-19e6-42ca-ad26-552707aef1cf.png">

Not-Empty Filter:

<img width="538" alt="magic_filter" src="https://user-images.githubusercontent.com/1517368/187212992-8b56d5ba-0ed9-4bed-a9c1-c32786602ccf.png">
