### PR TITLE
Use mappings definitions for auras and augmentations

### DIFF
--- a/src/components/Augmentations.vue
+++ b/src/components/Augmentations.vue
@@ -49,6 +49,7 @@
 <script>
 import Augmentation from "./Augmentation.vue";
 import { filterText } from "../helpers";
+import { AUGMENTATION_NAME } from "../mappings";
 
 export default {
   name: "Augmentations",
@@ -68,54 +69,7 @@ export default {
       return this.$store.getters.augmentationErrors;
     },
     augmentations() {
-      let collection = [
-        "archmages_endurance",
-        "asherons_benediction",
-        "asherons_lesser_benediction",
-        "blackmoors_favor",
-        "bleearghs_fortitude",
-        "caustic_enhancement",
-        "celdiseths_essence",
-        "charmed_smith",
-        "ciandras_essence",
-        "ciandras_fortune",
-        "clutch_of_the_miser",
-        "critical_protection",
-        "enduring_calm",
-        "enduring_enchantment",
-        "enhancement_of_the_arrow_turner",
-        "enhancement_of_the_blade_turner",
-        "enhancement_of_the_mace_turner",
-        "eye_of_the_remorseless",
-        "fiery_enhancement",
-        "frenzy_of_the_slayer",
-        "hand_of_the_remorseless",
-        "icy_enhancement",
-        "infused_creature_magic",
-        "infused_item_magic",
-        "infused_life_magic",
-        "infused_void_magic",
-        "infused_war_magic",
-        "innate_renewal",
-        "iron_skin_of_the_invincible",
-        "jack_of_all_trades",
-        "jibrils_essence",
-        "kogas_essence",
-        "master_of_the_five_fold_path",
-        "master_of_the_focused_eye",
-        "master_of_the_steel_circle",
-        "might_of_the_seventh_mule",
-        "oswalds_enhancement",
-        "quick_learner",
-        "reinforcement_of_the_lugians",
-        "shadow_of_the_seventh_mule",
-        "siraluuns_blessing",
-        "steadfast_will",
-        "storms_enhancement",
-        "yoshis_essence"
-      ]
-
-      return filterText(this.filterQuery, collection);
+      return filterText(this.filterQuery, Object.keys(AUGMENTATION_NAME));
     },
     filterPresent() {
       return this.filterQuery !== "";

--- a/src/components/LuminanceAuras.vue
+++ b/src/components/LuminanceAuras.vue
@@ -49,6 +49,7 @@
 <script>
 import LuminanceAura from "./LuminanceAura.vue";
 import { filterText } from "../helpers";
+import { LUMINANCE_AURA_NAME } from "../mappings";
 
 export default {
   name: "LuminanceAuras",
@@ -68,26 +69,7 @@ export default {
       return this.$store.getters.auraErrors;
     },
     auras() {
-      let collection = [
-        "aetheric_vision",
-        "craftsman",
-        "destruction",
-        "glory",
-        "hardening",
-        "invulnerability",
-        "mana_flow",
-        "mana_infusion",
-        "protection",
-        "purity",
-        "retribution",
-        "skill",
-        "specialization",
-        "temperance",
-        "valor",
-        "world"
-      ];
-
-      return filterText(this.filterQuery, collection);
+      return filterText(this.filterQuery, Object.keys(LUMINANCE_AURA_NAME));
     },
     filterPresent() {
       return this.filterQuery !== "";


### PR DESCRIPTION
Follow up to https://github.com/amoeba/accharplanner/pull/393 that uses the already existing constants defined in `mappings.ts` for auras and augmentations.

Still the same as before, but I suppose this highlights that the filter works on the snake cased key and not the display name.