### PR TITLE
Beer attribute buffs

### DIFF
--- a/src/components/Attribute.vue
+++ b/src/components/Attribute.vue
@@ -46,6 +46,7 @@
         <option value="6">VI</option>
         <option value="7">VII</option>
         <option value="8">VIII</option>
+        <option value="9">Beer</option>
       </select>
     </td>
     <td>

--- a/src/components/Attributes.vue
+++ b/src/components/Attributes.vue
@@ -37,6 +37,7 @@
           <option value="6">VI</option>
           <option value="7">VII</option>
           <option value="8">VIII</option>
+          <option value="9">Beer</option>
         </select>
       </th>
       <th>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,6 +35,8 @@ export const buffBonus = function (level: number) {
       return 40;
     case 8:
       return 45;
+    case 9: // Beer
+      return 50;
     default:
       return 0;
   }


### PR DESCRIPTION
Adds "Beer" as an Attribute "Buff" option. 
- +50 to buffed attributes
- Stacks with cantrips
- Does not stack with I-VIII attribute buffs.

Issue: https://github.com/amoeba/accharplanner/issues/223
Wiki: http://acpedia.org/wiki/Beer

<img width="536" alt="beer" src="https://user-images.githubusercontent.com/1517368/203807775-03e6dad8-5643-4f98-bca6-deb068f5ae9a.png">

