### PR TITLE
Refactor change-all mutations to actions

### DIFF
--- a/src/components/Attribute.vue
+++ b/src/components/Attribute.vue
@@ -25,7 +25,7 @@
       {{ buffed }}
     </td>
     <td>
-      <input type="range" min="0" max="190" v-model="invested" />
+      <input type="range" min="0" :max="maxAttributeInvested" v-model="invested" />
     </td>
     <td class="invested number">
       <input
@@ -62,6 +62,7 @@
 </template>
 
 <script>
+import { MAX_ATTRIBUTE_INVESTED } from '../constants';
 import { ATTRIBUTE_NAME, BUFF_NAME, CANTRIP_NAME } from "../mappings";
 
 export default {
@@ -69,6 +70,11 @@ export default {
   props: {
     name: String,
     tabIndex: String,
+  },
+  data() {
+    return {
+      maxAttributeInvested: MAX_ATTRIBUTE_INVESTED
+    };
   },
   computed: {
     displayName() {
@@ -175,8 +181,8 @@ export default {
         value = 0;
       }
 
-      if (value > 190) {
-        value = 190;
+      if (value > MAX_ATTRIBUTE_INVESTED) {
+        value = MAX_ATTRIBUTE_INVESTED;
       } else if (value < 0) {
         value = 0;
       }

--- a/src/components/Attributes.vue
+++ b/src/components/Attributes.vue
@@ -72,7 +72,7 @@ export default {
       this.$store.dispatch("changeAllAttributeInvestment", e.target.value);
     },
     changeBuffed(e) {
-      this.$store.commit("changeAllAttributeBuffs", e.target.value);
+      this.$store.dispatch("changeAllAttributeBuffs", e.target.value);
     },
     changeCantrip(e) {
       this.$store.commit("changeAllAttributeCantrips", e.target.value);

--- a/src/components/Attributes.vue
+++ b/src/components/Attributes.vue
@@ -20,7 +20,7 @@
         <input
           type="range"
           min="0"
-          max="190"
+          :max="maxAttributeInvested"
           value="0"
           v-on:change="changeInvested"
         />
@@ -60,12 +60,18 @@
 </template>
 
 <script>
+import { MAX_ATTRIBUTE_INVESTED } from '../constants';
 import Attribute from "./Attribute.vue";
 
 export default {
   name: "Attributes",
   components: {
     Attribute,
+  },
+  data() {
+    return {
+      maxAttributeInvested: MAX_ATTRIBUTE_INVESTED
+    };
   },
   methods: {
     changeInvested(e) {

--- a/src/components/Attributes.vue
+++ b/src/components/Attributes.vue
@@ -75,7 +75,7 @@ export default {
       this.$store.dispatch("changeAllAttributeBuffs", e.target.value);
     },
     changeCantrip(e) {
-      this.$store.commit("changeAllAttributeCantrips", e.target.value);
+      this.$store.dispatch("changeAllAttributeCantrips", e.target.value);
     },
   },
 };

--- a/src/components/Attributes.vue
+++ b/src/components/Attributes.vue
@@ -69,7 +69,7 @@ export default {
   },
   methods: {
     changeInvested(e) {
-      this.$store.commit("changeAllAttributeInvestment", e.target.value);
+      this.$store.dispatch("changeAllAttributeInvestment", e.target.value);
     },
     changeBuffed(e) {
       this.$store.commit("changeAllAttributeBuffs", e.target.value);

--- a/src/components/Headers.vue
+++ b/src/components/Headers.vue
@@ -284,13 +284,13 @@ export default {
       this.$store.commit("updateLevel", actual);
     },
     changeAllInvestments(e) {
-      this.$store.commit("changeAllInvestment", e.target.value);
+      this.$store.dispatch("changeAllInvestment", e.target.value);
     },
     changeAllBuffs(e) {
-      this.$store.commit("changeAllBuffs", e.target.value);
+      this.$store.dispatch("changeAllBuffs", e.target.value);
     },
     changeAllCantrips(e) {
-      this.$store.commit("changeAllCantrips", e.target.value);
+      this.$store.dispatch("changeAllCantrips", e.target.value);
     },
   },
 };

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -261,7 +261,7 @@ export default {
       this.$store.dispatch("changeAllSkillInvestment", e.target.value);
     },
     changeBuffed(e) {
-      this.$store.commit("changeAllSkillBuffs", e.target.value);
+      this.$store.dispatch("changeAllSkillBuffs", e.target.value);
     },
     changeCantrips(e) {
       this.$store.commit("changeAllSkillCantrips", e.target.value);

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -264,7 +264,7 @@ export default {
       this.$store.dispatch("changeAllSkillBuffs", e.target.value);
     },
     changeCantrips(e) {
-      this.$store.commit("changeAllSkillCantrips", e.target.value);
+      this.$store.dispatch("changeAllSkillCantrips", e.target.value);
     },
     clearFilter() {
       this.filterQuery = "";

--- a/src/components/Skills.vue
+++ b/src/components/Skills.vue
@@ -258,7 +258,7 @@ export default {
       this.$store.commit("toggleSkillsPane");
     },
     changeInvested(e) {
-      this.$store.commit("changeAllSkillInvestment", e.target.value);
+      this.$store.dispatch("changeAllSkillInvestment", e.target.value);
     },
     changeBuffed(e) {
       this.$store.commit("changeAllSkillBuffs", e.target.value);

--- a/src/components/Vital.vue
+++ b/src/components/Vital.vue
@@ -19,7 +19,7 @@
       {{ buffed }}
     </td>
     <td>
-      <input type="range" min="0" max="196" v-model="invested" />
+      <input type="range" min="0" :max="maxVitalInvested" v-model="invested" />
     </td>
     <td class="invested number">
       <input
@@ -35,6 +35,7 @@
 </template>
 
 <script>
+import { MAX_VITAL_INVESTED } from '../constants';
 import { VITAL_FORMULA } from "../mappings";
 
 export default {
@@ -75,6 +76,11 @@ export default {
       },
     },
   },
+  data() {
+    return {
+      maxVitalInvested: MAX_VITAL_INVESTED
+    }
+  },
   methods: {
     updateInvested(e) {
       let value = Math.round(Number(e.target.value));
@@ -83,8 +89,8 @@ export default {
         value = 0;
       }
 
-      if (value > 196) {
-        value = 196;
+      if (value > MAX_VITAL_INVESTED) {
+        value = MAX_VITAL_INVESTED;
       } else if (value < 0) {
         value = 0;
       }

--- a/src/components/Vitals.vue
+++ b/src/components/Vitals.vue
@@ -36,7 +36,7 @@ export default {
   },
   methods: {
     changeInvested(e) {
-      this.$store.commit("changeAllVitalInvestment", e.target.value);
+      this.$store.dispatch("changeAllVitalInvestment", e.target.value);
     },
   },
 };

--- a/src/components/Vitals.vue
+++ b/src/components/Vitals.vue
@@ -11,7 +11,7 @@
         <input
           type="range"
           min="0"
-          max="196"
+          :max="maxVitalInvested"
           value="0"
           v-on:change="changeInvested"
         />
@@ -28,11 +28,17 @@
 
 <script>
 import Vital from "./Vital.vue";
+import { MAX_VITAL_INVESTED } from '../constants';
 
 export default {
   name: "Vitals",
   components: {
     Vital,
+  },
+  data() {
+    return {
+      maxVitalInvested: MAX_VITAL_INVESTED
+    };
   },
   methods: {
     changeInvested(e) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const MAX_CREATION_ATTRIBUTE_POINTS: number = 100;
 export const MAX_CREATION_ATTRIBUTE_TOTAL_POINTS: number = 330;
 export const MAX_SKILL_INVESTED_TRAINED = 208;
 export const MAX_SKILL_INVESTED_SPECIALIZED = 226;
+export const MAX_VITAL_INVESTED = 196;
 
 export const ATTRIBUTES: string[] = [
   Attribute.strength,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const MAX_CREATION_ATTRIBUTE_TOTAL_POINTS: number = 330;
 export const MAX_SKILL_INVESTED_TRAINED = 208;
 export const MAX_SKILL_INVESTED_SPECIALIZED = 226;
 export const MAX_VITAL_INVESTED = 196;
+export const MAX_ATTRIBUTE_INVESTED = 190;
 
 export const ATTRIBUTES: string[] = [
   Attribute.strength,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -204,12 +204,15 @@ export const updateAugmentationInvestedSideEffect = function (
   }
 };
 
-export const computeSkillInvested = function(training: Training, invested: string) {
-  if (training === Training.SPECIALIZED) {
-    return Math.min(Number(invested), MAX_SKILL_INVESTED_SPECIALIZED);
-  } else if (training === Training.TRAINED) {
-    return Math.min(Number(invested), MAX_SKILL_INVESTED_TRAINED)
-  } else {
+const maxInvestedForTraining = (training: Training) => {
+  if (training === Training.SPECIALIZED)
+    return MAX_SKILL_INVESTED_SPECIALIZED;
+  else if (training === Training.TRAINED)
+    return MAX_SKILL_INVESTED_TRAINED;
+  else
     return 0;
-  }
+};
+
+export const computeSkillInvested = function(training: Training, invested: number) {
+  return Math.min(invested, maxInvestedForTraining(training))
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -208,15 +208,9 @@ export const computeSkillInvested = function(training: Training, invested: strin
   let result = Number(invested);
 
   if (training === Training.SPECIALIZED) {
-    result =
-      result > MAX_SKILL_INVESTED_SPECIALIZED
-        ? MAX_SKILL_INVESTED_SPECIALIZED
-        : result;
+    result = Math.min(result, MAX_SKILL_INVESTED_SPECIALIZED);
   } else if (training === Training.TRAINED) {
-    result =
-      result > MAX_SKILL_INVESTED_TRAINED
-        ? MAX_SKILL_INVESTED_TRAINED
-        : result;
+    result = Math.min(result, MAX_SKILL_INVESTED_TRAINED)
   } else {
     result = 0;
   }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -205,14 +205,11 @@ export const updateAugmentationInvestedSideEffect = function (
 };
 
 export const computeSkillInvested = function(training: Training, invested: string) {
-  let result = Number(invested);
-
   if (training === Training.SPECIALIZED) {
-    result = Math.min(result, MAX_SKILL_INVESTED_SPECIALIZED);
+    return Math.min(Number(invested), MAX_SKILL_INVESTED_SPECIALIZED);
   } else if (training === Training.TRAINED) {
-    result = Math.min(result, MAX_SKILL_INVESTED_TRAINED)
+    return Math.min(Number(invested), MAX_SKILL_INVESTED_TRAINED)
   } else {
-    result = 0;
+    return 0;
   }
-  return result;
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,5 +1,7 @@
 import {
   MAX_CREATION_ATTRIBUTE_POINTS,
+  MAX_SKILL_INVESTED_SPECIALIZED,
+  MAX_SKILL_INVESTED_TRAINED,
   MIN_CREATION_ATTRIBUTE_POINTS,
 } from "./constants";
 import { Training } from "./types";
@@ -200,4 +202,23 @@ export const updateAugmentationInvestedSideEffect = function (
 
     state.build.character.attributes[attribute].creation = newVal;
   }
+};
+
+export const computeSkillInvested = function(training: Training, invested: string) {
+  let result = Number(invested);
+
+  if (training === Training.SPECIALIZED) {
+    result =
+      result > MAX_SKILL_INVESTED_SPECIALIZED
+        ? MAX_SKILL_INVESTED_SPECIALIZED
+        : result;
+  } else if (training === Training.TRAINED) {
+    result =
+      result > MAX_SKILL_INVESTED_TRAINED
+        ? MAX_SKILL_INVESTED_TRAINED
+        : result;
+  } else {
+    result = 0;
+  }
+  return result;
 };

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -204,15 +204,11 @@ export const updateAugmentationInvestedSideEffect = function (
   }
 };
 
-const maxInvestedForTraining = (training: Training) => {
+export const maxSkillInvested = (training: Training) => {
   if (training === Training.SPECIALIZED)
     return MAX_SKILL_INVESTED_SPECIALIZED;
   else if (training === Training.TRAINED)
     return MAX_SKILL_INVESTED_TRAINED;
   else
     return 0;
-};
-
-export const computeSkillInvested = function(training: Training, invested: number) {
-  return Math.min(invested, maxInvestedForTraining(training))
 };

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -156,13 +156,18 @@ export default {
   },
   changeAllBuffs(context: any, buff: string) {
     context.dispatch("changeAllAttributeBuffs", buff);
-    context.commit("changeAllSkillBuffs", buff);
+    context.dispatch("changeAllSkillBuffs", buff);
   },
   changeAllAttributeBuffs(context: any, buff: string) {
     Object.keys(Attribute).forEach(attribute => {
       context.commit("updateAttributeBuff", {name: attribute, value: buff});
     });
-  };
+  },
+  changeAllSkillBuffs(context: any, buff: string) {
+    Object.keys(Skill).forEach(skill => {
+      context.commit("updateSkillBuff", {name: skill, value: buff});
+    });
+  },
   changeAllCantrips(context: any, cantrip: string) {
     context.commit("changeAllAttributeCantrips", cantrip);
     context.commit("changeAllSkillCantrips", cantrip);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -2,7 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import { merge } from "lodash";
 import { createId } from "mnemonic-id";
 
-import { Character, Build, Attribute, Vital } from "../types";
+import { Character, Build, Attribute, Vital, Skill } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
 export default {
@@ -136,9 +136,8 @@ export default {
   },
   changeAllInvestment(context: any, invested: string) {
     context.dispatch("changeAllAttributeInvestment", invested);
-
     context.dispatch("changeAllVitalInvestment", invested);
-    context.commit("changeAllSkillInvestment", invested);
+    context.dispatch("changeAllSkillInvestment", invested);
   },
   changeAllAttributeInvestment(context: any, invested: string) {
     Object.keys(Attribute).forEach(a => {
@@ -148,6 +147,11 @@ export default {
   changeAllVitalInvestment(context: any, invested: string) {
     Object.keys(Vital).forEach(vital => {
       context.commit("updateVitalInvested", {name: vital, value: invested});
+    });
+  },
+  changeAllSkillInvestment(context: any, invested: string) {
+    Object.keys(Skill).forEach(skill => {
+      context.commit("updateSkillInvested", {name: skill, value: invested});
     });
   },
   changeAllBuffs(context: any, buff: string) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -2,7 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import { merge } from "lodash";
 import { createId } from "mnemonic-id";
 
-import { Character, Build } from "../types";
+import { Character, Build, Attribute } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
 export default {
@@ -135,9 +135,15 @@ export default {
     context.commit("reorderStages", newOrder);
   },
   changeAllInvestment(context: any, invested: string) {
-    context.commit("changeAllAttributeInvestment", invested);
+    context.dispatch("changeAllAttributeInvestment", invested);
+
     context.commit("changeAllVitalInvestment", invested);
     context.commit("changeAllSkillInvestment", invested);
+  },
+  changeAllAttributeInvestment(context: any, invested: string) {
+    Object.keys(Attribute).forEach(a => {
+      context.commit("updateAttributeInvested", {name: a, value: invested});
+    });
   },
   changeAllBuffs(context: any, buff: string) {
     context.commit("changeAllAttributeBuffs", buff);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -2,7 +2,7 @@ import { createClient } from "@supabase/supabase-js";
 import { merge } from "lodash";
 import { createId } from "mnemonic-id";
 
-import { Character, Build, Attribute } from "../types";
+import { Character, Build, Attribute, Vital } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
 export default {
@@ -137,12 +137,17 @@ export default {
   changeAllInvestment(context: any, invested: string) {
     context.dispatch("changeAllAttributeInvestment", invested);
 
-    context.commit("changeAllVitalInvestment", invested);
+    context.dispatch("changeAllVitalInvestment", invested);
     context.commit("changeAllSkillInvestment", invested);
   },
   changeAllAttributeInvestment(context: any, invested: string) {
     Object.keys(Attribute).forEach(a => {
       context.commit("updateAttributeInvested", {name: a, value: invested});
+    });
+  },
+  changeAllVitalInvestment(context: any, invested: string) {
+    Object.keys(Vital).forEach(vital => {
+      context.commit("updateVitalInvested", {name: vital, value: invested});
     });
   },
   changeAllBuffs(context: any, buff: string) {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -134,4 +134,17 @@ export default {
   reorderStages(context: any, newOrder: any) {
     context.commit("reorderStages", newOrder);
   },
+  changeAllInvestment(context: any, invested: string) {
+    context.commit("changeAllAttributeInvestment", invested);
+    context.commit("changeAllVitalInvestment", invested);
+    context.commit("changeAllSkillInvestment", invested);
+  },
+  changeAllBuffs(context: any, buff: string) {
+    context.commit("changeAllAttributeBuffs", buff);
+    context.commit("changeAllSkillBuffs", buff);
+  },
+  changeAllCantrips(context: any, cantrip: string) {
+    context.commit("changeAllAttributeCantrips", cantrip);
+    context.commit("changeAllSkillCantrips", cantrip);
+  },
 };

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -155,9 +155,14 @@ export default {
     });
   },
   changeAllBuffs(context: any, buff: string) {
-    context.commit("changeAllAttributeBuffs", buff);
+    context.dispatch("changeAllAttributeBuffs", buff);
     context.commit("changeAllSkillBuffs", buff);
   },
+  changeAllAttributeBuffs(context: any, buff: string) {
+    Object.keys(Attribute).forEach(attribute => {
+      context.commit("updateAttributeBuff", {name: attribute, value: buff});
+    });
+  };
   changeAllCantrips(context: any, cantrip: string) {
     context.commit("changeAllAttributeCantrips", cantrip);
     context.commit("changeAllSkillCantrips", cantrip);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -169,7 +169,12 @@ export default {
     });
   },
   changeAllCantrips(context: any, cantrip: string) {
-    context.commit("changeAllAttributeCantrips", cantrip);
+    context.dispatch("changeAllAttributeCantrips", cantrip);
     context.commit("changeAllSkillCantrips", cantrip);
+  },
+  changeAllAttributeCantrips(context: any, cantrip: string) {
+    Object.keys(Attribute).forEach(attribute => {
+      context.commit("updateAttributeCantrip", {name: attribute, value: cantrip});
+    });
   },
 };

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -170,11 +170,16 @@ export default {
   },
   changeAllCantrips(context: any, cantrip: string) {
     context.dispatch("changeAllAttributeCantrips", cantrip);
-    context.commit("changeAllSkillCantrips", cantrip);
+    context.dispatch("changeAllSkillCantrips", cantrip);
   },
   changeAllAttributeCantrips(context: any, cantrip: string) {
     Object.keys(Attribute).forEach(attribute => {
       context.commit("updateAttributeCantrip", {name: attribute, value: cantrip});
+    });
+  },
+  changeAllSkillCantrips(context: any, cantrip: string) {
+    Object.keys(Skill).forEach(skill => {
+      context.commit("updateSkillCantrip", {name: skill, value: cantrip});
     });
   },
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,18 +26,26 @@ import {
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
+const skillInvestedWithTraining = (training: Training, invested: number) => {
+  return Math.min(invested, maxSkillInvested(training));
+};
+
 const changeAllSkillInvestment = (state: State, invested: string) => {
-  Object.keys(Skill).forEach((skill) => {
-    const max = maxSkillInvested(state.build.character.skills[skill].training);
-    state.build.character.skills[skill].invested = Math.min(Number(invested), max);
-  });
+  Object
+    .keys(Skill)
+    .map(skill => state.build.character.skills[skill])
+    .forEach(skill => { 
+      skill.invested = skillInvestedWithTraining(skill.training, Number(invested)) 
+    });
 };
 
 const changeAllVitalInvestment = (state: State, invested: string) => {
-  Object.keys(Vital).forEach(v => {
-    const max = 196;
-    state.build.character.vitals[v].invested = Math.min(Number(invested), max);
-  });
+  Object
+    .keys(Vital)
+    .map(v => state.build.character.vitals[v])
+    .forEach(vital => {
+      vital.invested = Math.min(Number(invested), 196);
+    });
 };
 
 const changeAllAttributeInvestment = (state: State, invested: string) => {
@@ -326,7 +334,8 @@ export default {
   },
 
   updateSkillInvested(state: State, payload: { name: string; value: number }) {
-    state.build.character.skills[payload.name].invested = payload.value;
+    let skill = state.build.character.skills[payload.name];
+    skill.invested = skillInvestedWithTraining(skill.training, payload.value)
   },
 
   updateSkillBuff(state: State, payload: any) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -38,12 +38,6 @@ const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
 
-const changeAllSkillBuffs = (state: State, buff: string) => {
-  skills(state).forEach(skill => {
-    skill.buff = Number(buff);
-  });
-};
-
 const changeAllAttributeCantrips = (state: State, cantrip: string) => {
   attributes(state).forEach(attribute => {
     attribute.cantrip = Number(cantrip);
@@ -450,8 +444,6 @@ export default {
     });
   },
 
-  changeAllSkillBuffs,
-  
   changeAllAttributeCantrips,
 
   changeAllSkillCantrips,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -9,7 +9,10 @@ import {
   MAX_SKILL_INVESTED_SPECIALIZED,
   ATTRIBUTES,
 } from "../constants";
-import { updateAugmentationInvestedSideEffect } from "../helpers";
+import {
+  updateAugmentationInvestedSideEffect,
+  computeSkillInvested
+} from "../helpers";
 import {
   State,
   Race,
@@ -434,24 +437,11 @@ export default {
     });
 
     Object.keys(Skill).forEach((skill) => {
-      const training = state.build.character.skills[skill].training;
-      let newval = Number(invested);
-
-      if (training === Training.SPECIALIZED) {
-        newval =
-          newval > MAX_SKILL_INVESTED_SPECIALIZED
-            ? MAX_SKILL_INVESTED_SPECIALIZED
-            : newval;
-      } else if (training === Training.TRAINED) {
-        newval =
-          newval > MAX_SKILL_INVESTED_TRAINED
-            ? MAX_SKILL_INVESTED_TRAINED
-            : newval;
-      } else {
-        newval = 0;
-      }
-
-      state.build.character.skills[skill].invested = newval;
+      state.build.character.skills[skill].invested =
+        computeSkillInvested(
+          state.build.character.skills[skill].training,
+          invested
+        );
     });
   },
 
@@ -473,24 +463,11 @@ export default {
 
   changeAllSkillInvestment(state: State, invested: string) {
     Object.keys(Skill).forEach((skill) => {
-      const training = state.build.character.skills[skill].training;
-      let newval = Number(invested);
-
-      if (training === Training.SPECIALIZED) {
-        newval =
-          newval > MAX_SKILL_INVESTED_SPECIALIZED
-            ? MAX_SKILL_INVESTED_SPECIALIZED
-            : newval;
-      } else if (training === Training.TRAINED) {
-        newval =
-          newval > MAX_SKILL_INVESTED_TRAINED
-            ? MAX_SKILL_INVESTED_TRAINED
-            : newval;
-      } else {
-        newval = 0;
-      }
-
-      state.build.character.skills[skill].invested = newval;
+      state.build.character.skills[skill].invested =
+      computeSkillInvested(
+          state.build.character.skills[skill].training,
+          invested
+        );
     });
   },
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -7,6 +7,7 @@ import {
   MAX_CREATION_ATTRIBUTE_TOTAL_POINTS,
   MAX_SKILL_INVESTED_TRAINED,
   MAX_VITAL_INVESTED,
+  MAX_ATTRIBUTE_INVESTED,
 } from "../constants";
 import {
   updateAugmentationInvestedSideEffect,
@@ -258,7 +259,7 @@ export default {
   },
 
   updateAttributeInvested(state: State, payload: any) {
-    state.build.character.attributes[payload.name].invested = Math.min(Number(payload.value), 190);
+    state.build.character.attributes[payload.name].invested = Math.min(Number(payload.value), MAX_ATTRIBUTE_INVESTED);
   },
 
   updateAttributeBuff(state: State, payload: any) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,6 +6,7 @@ import {
   UNTRAINED_STATE,
   MAX_CREATION_ATTRIBUTE_TOTAL_POINTS,
   MAX_SKILL_INVESTED_TRAINED,
+  MAX_VITAL_INVESTED,
 } from "../constants";
 import {
   updateAugmentationInvestedSideEffect,
@@ -271,7 +272,7 @@ export default {
   },
 
   updateVitalInvested(state: State, payload: any) {
-    state.build.character.vitals[payload.name].invested = Math.min(Number(payload.value), 196);
+    state.build.character.vitals[payload.name].invested = Math.min(Number(payload.value), MAX_VITAL_INVESTED);
   },
 
   updateSkillInvested(state: State, payload: { name: string; value: number }) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,6 +26,12 @@ import {
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
+const changeAllSkillInvestment = (state: State, invested: string) => {
+  Object.keys(Skill).forEach((skill) => {
+    state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
+  });
+};
+
 export default {
   // UI toggles
   toggleDarkMode(state: State, preference: boolean) {
@@ -430,9 +436,7 @@ export default {
       state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
     });
 
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
-    });
+    changeAllSkillInvestment(state, invested);
   },
 
   changeAllAttributeInvestment(state: State, invested: string) {
@@ -451,11 +455,7 @@ export default {
     });
   },
 
-  changeAllSkillInvestment(state: State, invested: string) {
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
-    });
-  },
+  changeAllSkillInvestment,
 
   changeAllBuffs(state: State, buff: string) {
     Object.keys(Attribute).forEach((attribute) => {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,10 +26,6 @@ import {
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
-const skillInvestedWithTraining = (training: Training, invested: number) => {
-  return Math.min(invested, maxSkillInvested(training));
-};
-
 export default {
   // UI toggles
   toggleDarkMode(state: State, preference: boolean) {
@@ -284,7 +280,8 @@ export default {
 
   updateSkillInvested(state: State, payload: { name: string; value: number }) {
     let skill = state.build.character.skills[payload.name];
-    skill.invested = skillInvestedWithTraining(skill.training, payload.value)
+    const max = maxSkillInvested(skill.training)
+    skill.invested = Math.min(payload.value, max);
   },
 
   updateSkillBuff(state: State, payload: any) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -48,12 +48,6 @@ const changeAllSkillInvestment = (state: State, invested: string) => {
   });
 };
 
-const changeAllVitalInvestment = (state: State, invested: string) => {
-  vitals(state).forEach(vital => {
-    vital.invested = Math.min(Number(invested), 196);
-  });
-};  
-
 const changeAllAttributeBuffs = (state: State, buff: string) => {
   attributes(state).forEach(attribute => {
     attribute.buff = Number(buff);
@@ -327,7 +321,7 @@ export default {
   },
 
   updateVitalInvested(state: State, payload: any) {
-    state.build.character.vitals[payload.name].invested = Number(payload.value);
+    state.build.character.vitals[payload.name].invested = Math.min(Number(payload.value), 196);
   },
 
   updateSkillInvested(state: State, payload: { name: string; value: number }) {
@@ -471,8 +465,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllVitalInvestment,
 
   changeAllSkillInvestment,
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -56,6 +56,18 @@ const changeAllSkillBuffs = (state: State, buff: string) => {
   });
 };
 
+const changeAllAttributeCantrips = (state: State, cantrip: string) => {
+  Object.keys(Attribute).forEach((attribute) => {
+    state.build.character.attributes[attribute].cantrip = Number(cantrip);
+  });
+};
+
+const changeAllSkillCantrips = (state: State, cantrip: string) => {
+  Object.keys(Skill).forEach((skill) => {
+    state.build.character.skills[skill].cantrip = Number(cantrip);
+  });
+};
+
 export default {
   // UI toggles
   toggleDarkMode(state: State, preference: boolean) {
@@ -474,26 +486,13 @@ export default {
 
   // Cantrips
   changeAllCantrips(state: State, cantrip: string) {
-    Object.keys(Attribute).forEach((attribute) => {
-      state.build.character.attributes[attribute].cantrip = Number(cantrip);
-    });
-
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].cantrip = Number(cantrip);
-    });
+    changeAllAttributeCantrips(state, cantrip);
+    changeAllSkillCantrips(state, cantrip);
   },
 
-  changeAllAttributeCantrips(state: State, cantrip: string) {
-    Object.keys(Attribute).forEach((attribute) => {
-      state.build.character.attributes[attribute].cantrip = Number(cantrip);
-    });
-  },
+  changeAllAttributeCantrips,
 
-  changeAllSkillCantrips(state: State, cantrip: string) {
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].cantrip = Number(cantrip);
-    });
-  },
+  changeAllSkillCantrips,
 
   // Notifications
   clearAllNotifications(state: State) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -434,18 +434,15 @@ export default {
     });
 
     Object.keys(Skill).forEach((skill) => {
+      const training = state.build.character.skills[skill].training;
       let newval = Number(invested);
 
-      if (
-        state.build.character.skills[skill].training === Training.SPECIALIZED
-      ) {
+      if (training === Training.SPECIALIZED) {
         newval =
-          newval > MAX_SKILL_INVESTED_SPECIALIZED 
+          newval > MAX_SKILL_INVESTED_SPECIALIZED
             ? MAX_SKILL_INVESTED_SPECIALIZED
             : newval;
-      } else if (
-        state.build.character.skills[skill].training === Training.TRAINED
-      ) {
+      } else if (training === Training.TRAINED) {
         newval =
           newval > MAX_SKILL_INVESTED_TRAINED
             ? MAX_SKILL_INVESTED_TRAINED
@@ -476,18 +473,15 @@ export default {
 
   changeAllSkillInvestment(state: State, invested: string) {
     Object.keys(Skill).forEach((skill) => {
+      const training = state.build.character.skills[skill].training;
       let newval = Number(invested);
 
-      if (
-        state.build.character.skills[skill].training === Training.SPECIALIZED
-      ) {
+      if (training === Training.SPECIALIZED) {
         newval =
           newval > MAX_SKILL_INVESTED_SPECIALIZED
             ? MAX_SKILL_INVESTED_SPECIALIZED
             : newval;
-      } else if (
-        state.build.character.skills[skill].training === Training.TRAINED
-      ) {
+      } else if (training === Training.TRAINED) {
         newval =
           newval > MAX_SKILL_INVESTED_TRAINED
             ? MAX_SKILL_INVESTED_TRAINED

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -440,7 +440,7 @@ export default {
       state.build.character.skills[skill].invested =
         computeSkillInvested(
           state.build.character.skills[skill].training,
-          invested
+          Number(invested)
         );
     });
   },
@@ -466,7 +466,7 @@ export default {
       state.build.character.skills[skill].invested =
       computeSkillInvested(
           state.build.character.skills[skill].training,
-          invested
+          Number(invested)
         );
     });
   },

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -42,12 +42,6 @@ const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
 
-const changeAllSkillInvestment = (state: State, invested: string) => {
-  skills(state).forEach(skill => { 
-    skill.invested = skillInvestedWithTraining(skill.training, Number(invested)) 
-  });
-};
-
 const changeAllAttributeBuffs = (state: State, buff: string) => {
   attributes(state).forEach(attribute => {
     attribute.buff = Number(buff);
@@ -465,8 +459,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllSkillInvestment,
 
   changeAllAttributeBuffs,
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -31,6 +31,13 @@ const changeAllSkillInvestment = (state: State, invested: string) => {
     state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
   });
 };
+
+const changeAllVitalInvestment = (state: State, invested: string) => {
+  Object.keys(Vital).forEach(v => {
+    state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
+  });
+};
+
 const changeAllAttributeInvestment = (state: State, invested: string) => {
   Object.keys(Attribute).forEach(a => {
     state.build.character.attributes[a].invested = Math.min(Number(invested), 190);
@@ -433,25 +440,14 @@ export default {
   },
 
   changeAllInvestment(state: State, invested: string) {
-
     changeAllAttributeInvestment(state, invested);
-
-    Object.keys(Vital).forEach(v => {
-      state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
-    });
-
+    changeAllVitalInvestment(state, invested);
     changeAllSkillInvestment(state, invested);
   },
 
   changeAllAttributeInvestment,
 
-  changeAllVitalInvestment(state: State, invested: string) {
-    Object.keys(Vital).forEach((a) => {
-      let newval = Number(invested);
-
-      state.build.character.vitals[a].invested = newval;
-    });
-  },
+  changeAllVitalInvestment,
 
   changeAllSkillInvestment,
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -44,6 +44,18 @@ const changeAllAttributeInvestment = (state: State, invested: string) => {
   });
 };
 
+const changeAllAttributeBuffs = (state: State, buff: string) => {
+  Object.keys(Attribute).forEach((attribute) => {
+    state.build.character.attributes[attribute].buff = Number(buff);
+  });
+};
+
+const changeAllSkillBuffs = (state: State, buff: string) => {
+  Object.keys(Skill).forEach((skill) => {
+    state.build.character.skills[skill].buff = Number(buff);
+  });
+};
+
 export default {
   // UI toggles
   toggleDarkMode(state: State, preference: boolean) {
@@ -452,26 +464,13 @@ export default {
   changeAllSkillInvestment,
 
   changeAllBuffs(state: State, buff: string) {
-    Object.keys(Attribute).forEach((attribute) => {
-      state.build.character.attributes[attribute].buff = Number(buff);
-    });
-
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].buff = Number(buff);
-    });
+    changeAllAttributeBuffs(state, buff);
+    changeAllSkillBuffs(state, buff);
   },
 
-  changeAllAttributeBuffs(state: State, buff: string) {
-    Object.keys(Attribute).forEach((attribute) => {
-      state.build.character.attributes[attribute].buff = Number(buff);
-    });
-  },
+  changeAllAttributeBuffs,
 
-  changeAllSkillBuffs(state: State, buff: string) {
-    Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].buff = Number(buff);
-    });
-  },
+  changeAllSkillBuffs,
 
   // Cantrips
   changeAllCantrips(state: State, cantrip: string) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -437,16 +437,24 @@ export default {
       let newval = Number(invested);
 
       if (
-        state.build.character.skills[skill].training == Training.SPECIALIZED
+        state.build.character.skills[skill].training === Training.SPECIALIZED
       ) {
-        state.build.character.skills[skill].invested =
-          newval > MAX_SKILL_INVESTED_SPECIALIZED ? MAX_SKILL_INVESTED_SPECIALIZED : newval;
+        newval =
+          newval > MAX_SKILL_INVESTED_SPECIALIZED 
+            ? MAX_SKILL_INVESTED_SPECIALIZED
+            : newval;
       } else if (
-        state.build.character.skills[skill].training == Training.TRAINED
+        state.build.character.skills[skill].training === Training.TRAINED
       ) {
-        state.build.character.skills[skill].invested =
-          newval > MAX_SKILL_INVESTED_TRAINED ? MAX_SKILL_INVESTED_TRAINED : newval;
+        newval =
+          newval > MAX_SKILL_INVESTED_TRAINED
+            ? MAX_SKILL_INVESTED_TRAINED
+            : newval;
+      } else {
+        newval = 0;
       }
+
+      state.build.character.skills[skill].invested = newval;
     });
   },
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -34,6 +34,10 @@ const vitals = (state: State) => {
   return Object.keys(Vital).map(v => state.build.character.vitals[v])
 };
 
+const attributes = (state: State) => {
+  return Object.keys(Attribute).map(a => state.build.character.attributes[a])
+};
+
 const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
@@ -51,21 +55,15 @@ const changeAllVitalInvestment = (state: State, invested: string) => {
 };
 
 const changeAllAttributeInvestment = (state: State, invested: string) => {
-  Object
-    .keys(Attribute)
-    .map(a => state.build.character.attributes[a])
-    .forEach(a => {
-      a.invested = Math.min(Number(invested), 190);
-    });
+  attributes(state).forEach(a => {
+    a.invested = Math.min(Number(invested), 190);
+  });
 };
 
 const changeAllAttributeBuffs = (state: State, buff: string) => {
-  Object
-    .keys(Attribute)
-    .map(a => state.build.character.attributes[a])
-    .forEach(attribute => {
-      attribute.buff = Number(buff);
-    });
+  attributes(state).forEach(attribute => {
+    attribute.buff = Number(buff);
+  });
 };
 
 const changeAllSkillBuffs = (state: State, buff: string) => {
@@ -75,12 +73,9 @@ const changeAllSkillBuffs = (state: State, buff: string) => {
 };
 
 const changeAllAttributeCantrips = (state: State, cantrip: string) => {
-  Object
-    .keys(Attribute)
-    .map(a => state.build.character.attributes[a])
-    .forEach(attribute => {
-      attribute.cantrip = Number(cantrip);
-    });
+  attributes(state).forEach(attribute => {
+    attribute.cantrip = Number(cantrip);
+  });
 };
 
 const changeAllSkillCantrips = (state: State, cantrip: string) => {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -31,6 +31,11 @@ const changeAllSkillInvestment = (state: State, invested: string) => {
     state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
   });
 };
+const changeAllAttributeInvestment = (state: State, invested: string) => {
+  Object.keys(Attribute).forEach(a => {
+    state.build.character.attributes[a].invested = Math.min(Number(invested), 190);
+  });
+};
 
 export default {
   // UI toggles
@@ -428,9 +433,8 @@ export default {
   },
 
   changeAllInvestment(state: State, invested: string) {
-    Object.keys(Attribute).forEach(a => {
-      state.build.character.attributes[a].invested = Math.min(Number(invested), 190);
-    });
+
+    changeAllAttributeInvestment(state, invested);
 
     Object.keys(Vital).forEach(v => {
       state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
@@ -439,13 +443,7 @@ export default {
     changeAllSkillInvestment(state, invested);
   },
 
-  changeAllAttributeInvestment(state: State, invested: string) {
-    Object.keys(Attribute).forEach((a) => {
-      let newval = Number(invested);
-
-      state.build.character.attributes[a].invested = newval;
-    });
-  },
+  changeAllAttributeInvestment,
 
   changeAllVitalInvestment(state: State, invested: string) {
     Object.keys(Vital).forEach((a) => {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,18 +26,8 @@ import {
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
-const skills = (state: State) => {
-  return Object.keys(Skill).map(skill => state.build.character.skills[skill])
-};
-
 const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
-};
-
-const changeAllSkillCantrips = (state: State, cantrip: string) => {
-  skills(state).forEach(skill => {
-    skill.cantrip = Number(cantrip);
-  });
 };
 
 export default {
@@ -433,8 +423,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllSkillCantrips,
 
   // Notifications
   clearAllNotifications(state: State) {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -28,19 +28,22 @@ import DefaultCharacter from "./DefaultCharacter";
 
 const changeAllSkillInvestment = (state: State, invested: string) => {
   Object.keys(Skill).forEach((skill) => {
-    state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
+    const max = maxSkillInvested(state.build.character.skills[skill].training);
+    state.build.character.skills[skill].invested = Math.min(Number(invested), max);
   });
 };
 
 const changeAllVitalInvestment = (state: State, invested: string) => {
   Object.keys(Vital).forEach(v => {
-    state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
+    const max = 196;
+    state.build.character.vitals[v].invested = Math.min(Number(invested), max);
   });
 };
 
 const changeAllAttributeInvestment = (state: State, invested: string) => {
   Object.keys(Attribute).forEach(a => {
-    state.build.character.attributes[a].invested = Math.min(Number(invested), 190);
+    const max = 190;
+    state.build.character.attributes[a].invested = Math.min(Number(invested), max);
   });
 };
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -30,18 +30,8 @@ const skills = (state: State) => {
   return Object.keys(Skill).map(skill => state.build.character.skills[skill])
 };
 
-const attributes = (state: State) => {
-  return Object.keys(Attribute).map(a => state.build.character.attributes[a])
-};
-
 const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
-};
-
-const changeAllAttributeCantrips = (state: State, cantrip: string) => {
-  attributes(state).forEach(attribute => {
-    attribute.cantrip = Number(cantrip);
-  });
 };
 
 const changeAllSkillCantrips = (state: State, cantrip: string) => {
@@ -443,8 +433,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllAttributeCantrips,
 
   changeAllSkillCantrips,
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -52,13 +52,7 @@ const changeAllVitalInvestment = (state: State, invested: string) => {
   vitals(state).forEach(vital => {
     vital.invested = Math.min(Number(invested), 196);
   });
-};
-
-const changeAllAttributeInvestment = (state: State, invested: string) => {
-  attributes(state).forEach(a => {
-    a.invested = Math.min(Number(invested), 190);
-  });
-};
+};  
 
 const changeAllAttributeBuffs = (state: State, buff: string) => {
   attributes(state).forEach(attribute => {
@@ -319,9 +313,7 @@ export default {
   },
 
   updateAttributeInvested(state: State, payload: any) {
-    state.build.character.attributes[payload.name].invested = Number(
-      payload.value
-    );
+    state.build.character.attributes[payload.name].invested = Math.min(Number(payload.value), 190);
   },
 
   updateAttributeBuff(state: State, payload: any) {
@@ -479,8 +471,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllAttributeInvestment,
 
   changeAllVitalInvestment,
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -30,6 +30,10 @@ const skills = (state: State) => {
   return Object.keys(Skill).map(skill => state.build.character.skills[skill])
 };
 
+const vitals = (state: State) => {
+  return Object.keys(Vital).map(v => state.build.character.vitals[v])
+};
+
 const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
@@ -41,12 +45,9 @@ const changeAllSkillInvestment = (state: State, invested: string) => {
 };
 
 const changeAllVitalInvestment = (state: State, invested: string) => {
-  Object
-    .keys(Vital)
-    .map(v => state.build.character.vitals[v])
-    .forEach(vital => {
-      vital.invested = Math.min(Number(invested), 196);
-    });
+  vitals(state).forEach(vital => {
+    vital.invested = Math.min(Number(invested), 196);
+  });
 };
 
 const changeAllAttributeInvestment = (state: State, invested: string) => {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -26,17 +26,18 @@ import {
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";
 
+const skills = (state: State) => {
+  return Object.keys(Skill).map(skill => state.build.character.skills[skill])
+};
+
 const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
 
 const changeAllSkillInvestment = (state: State, invested: string) => {
-  Object
-    .keys(Skill)
-    .map(skill => state.build.character.skills[skill])
-    .forEach(skill => { 
-      skill.invested = skillInvestedWithTraining(skill.training, Number(invested)) 
-    });
+  skills(state).forEach(skill => { 
+    skill.invested = skillInvestedWithTraining(skill.training, Number(invested)) 
+  });
 };
 
 const changeAllVitalInvestment = (state: State, invested: string) => {
@@ -49,33 +50,41 @@ const changeAllVitalInvestment = (state: State, invested: string) => {
 };
 
 const changeAllAttributeInvestment = (state: State, invested: string) => {
-  Object.keys(Attribute).forEach(a => {
-    const max = 190;
-    state.build.character.attributes[a].invested = Math.min(Number(invested), max);
-  });
+  Object
+    .keys(Attribute)
+    .map(a => state.build.character.attributes[a])
+    .forEach(a => {
+      a.invested = Math.min(Number(invested), 190);
+    });
 };
 
 const changeAllAttributeBuffs = (state: State, buff: string) => {
-  Object.keys(Attribute).forEach((attribute) => {
-    state.build.character.attributes[attribute].buff = Number(buff);
-  });
+  Object
+    .keys(Attribute)
+    .map(a => state.build.character.attributes[a])
+    .forEach(attribute => {
+      attribute.buff = Number(buff);
+    });
 };
 
 const changeAllSkillBuffs = (state: State, buff: string) => {
-  Object.keys(Skill).forEach((skill) => {
-    state.build.character.skills[skill].buff = Number(buff);
+  skills(state).forEach(skill => {
+    skill.buff = Number(buff);
   });
 };
 
 const changeAllAttributeCantrips = (state: State, cantrip: string) => {
-  Object.keys(Attribute).forEach((attribute) => {
-    state.build.character.attributes[attribute].cantrip = Number(cantrip);
-  });
+  Object
+    .keys(Attribute)
+    .map(a => state.build.character.attributes[a])
+    .forEach(attribute => {
+      attribute.cantrip = Number(cantrip);
+    });
 };
 
 const changeAllSkillCantrips = (state: State, cantrip: string) => {
-  Object.keys(Skill).forEach((skill) => {
-    state.build.character.skills[skill].cantrip = Number(cantrip);
+  skills(state).forEach(skill => {
+    skill.cantrip = Number(cantrip);
   });
 };
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -480,33 +480,16 @@ export default {
     });
   },
 
-  changeAllInvestment(state: State, invested: string) {
-    changeAllAttributeInvestment(state, invested);
-    changeAllVitalInvestment(state, invested);
-    changeAllSkillInvestment(state, invested);
-  },
-
   changeAllAttributeInvestment,
 
   changeAllVitalInvestment,
 
   changeAllSkillInvestment,
 
-  changeAllBuffs(state: State, buff: string) {
-    changeAllAttributeBuffs(state, buff);
-    changeAllSkillBuffs(state, buff);
-  },
-
   changeAllAttributeBuffs,
 
   changeAllSkillBuffs,
-
-  // Cantrips
-  changeAllCantrips(state: State, cantrip: string) {
-    changeAllAttributeCantrips(state, cantrip);
-    changeAllSkillCantrips(state, cantrip);
-  },
-
+  
   changeAllAttributeCantrips,
 
   changeAllSkillCantrips,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -30,10 +30,6 @@ const skills = (state: State) => {
   return Object.keys(Skill).map(skill => state.build.character.skills[skill])
 };
 
-const vitals = (state: State) => {
-  return Object.keys(Vital).map(v => state.build.character.vitals[v])
-};
-
 const attributes = (state: State) => {
   return Object.keys(Attribute).map(a => state.build.character.attributes[a])
 };

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -38,12 +38,6 @@ const skillInvestedWithTraining = (training: Training, invested: number) => {
   return Math.min(invested, maxSkillInvested(training));
 };
 
-const changeAllAttributeBuffs = (state: State, buff: string) => {
-  attributes(state).forEach(attribute => {
-    attribute.buff = Number(buff);
-  });
-};
-
 const changeAllSkillBuffs = (state: State, buff: string) => {
   skills(state).forEach(skill => {
     skill.buff = Number(buff);
@@ -455,8 +449,6 @@ export default {
         value == 1 ? LUMINANCE_AURA_MAX_USES[aura_name] : 0;
     });
   },
-
-  changeAllAttributeBuffs,
 
   changeAllSkillBuffs,
   

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -11,7 +11,7 @@ import {
 } from "../constants";
 import {
   updateAugmentationInvestedSideEffect,
-  computeSkillInvested
+  maxSkillInvested
 } from "../helpers";
 import {
   State,
@@ -422,26 +422,16 @@ export default {
   },
 
   changeAllInvestment(state: State, invested: string) {
-    Object.keys(Attribute).forEach((a) => {
-      let newval = Number(invested);
-      newval = newval > 190 ? 190 : newval;
-
-      state.build.character.attributes[a].invested = newval;
+    Object.keys(Attribute).forEach(a => {
+      state.build.character.attributes[a].invested = Math.min(Number(invested), 190);
     });
 
-    Object.keys(Vital).forEach((a) => {
-      let newval = Number(invested);
-      newval = newval > 196 ? 196 : newval;
-
-      state.build.character.vitals[a].invested = newval;
+    Object.keys(Vital).forEach(v => {
+      state.build.character.vitals[v].invested = Math.min(Number(invested), 196);
     });
 
     Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].invested =
-        computeSkillInvested(
-          state.build.character.skills[skill].training,
-          Number(invested)
-        );
+      state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
     });
   },
 
@@ -463,11 +453,7 @@ export default {
 
   changeAllSkillInvestment(state: State, invested: string) {
     Object.keys(Skill).forEach((skill) => {
-      state.build.character.skills[skill].invested =
-      computeSkillInvested(
-          state.build.character.skills[skill].training,
-          Number(invested)
-        );
+      state.build.character.skills[skill].invested = Math.min(Number(invested), maxSkillInvested(state.build.character.skills[skill].training));
     });
   },
 

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,8 +6,6 @@ import {
   UNTRAINED_STATE,
   MAX_CREATION_ATTRIBUTE_TOTAL_POINTS,
   MAX_SKILL_INVESTED_TRAINED,
-  MAX_SKILL_INVESTED_SPECIALIZED,
-  ATTRIBUTES,
 } from "../constants";
 import {
   updateAugmentationInvestedSideEffect,
@@ -18,10 +16,8 @@ import {
   Race,
   Gender,
   Attribute,
-  Vital,
   Skill,
   Training,
-  LuminanceAura,
   Augmentation,
 } from "../types";
 import DefaultCharacter from "./DefaultCharacter";


### PR DESCRIPTION
There is a pattern of mutations surrounding `changeAll*` that has produced some duplication. For example, there's a change all mutation for investing attributes, skills, vitals -- as well as single target mutations of all these. Then again for buffs and cantrips. Considering the key loops and deep object state navigation needed for each, I think this branch could be a positive change.

This branch eliminates duplicate logic and inconsistent maximum enforcement by continuing to use mutations for single/atomic changes, but moving to actions for coordinating and composing these small mutations into the "all" use cases.

Originally explored lifting mutation functions out of the `export default` so that the functions could reference each other but it started spreading out pass-by-reference assignments. I think leveraging actions(the framework) for coordinating smaller mutations came out better. Feel free to squash the commits as this exploration is present in the commit history 😄 
